### PR TITLE
rai-sdk 0.7.4 ❄️ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # rai-sdk-feedstock
 The RelationalAI Software Development Kit for Python
+
+home: https://relational.ai/
+license: Apache-2.0
+license_family: APACHE
+license_file: LICENSE
+summary: "The RelationalAI Software Development Kit for Python"
+description: |
+  The RelationalAI (RAI) SDK for Python enables developers to access
+  the RAI REST APIs from Python.
+doc_url: https://docs.relational.ai/rkgms/sdk/python-sdk
+dev_url: https://github.com/RelationalAI/rai-sdk-python
+
+feedstock-license: BSD 3-Clause License

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,19 +21,24 @@ requirements:
     - wheel
   run:
     - python
-    - pandas >=2.0.0,<3.0.0
+    - pandas >=2.0.0,<3.0.0     # [py>38]
     - protobuf >=3.20.3,<5.0.0
     - pyarrow >=10.0.0,<16.0.0
     - requests-toolbelt ==1.0.0
 
 test:
+  source_files:
+    # test/test_integration.py uses GH secrets etc.
+    - test/test_unit.py
   imports:
     - railib
     - railib.pb
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v test
 
 about:
   home: https://relational.ai/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "rai-sdk" %}
+{% set version = "0.7.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f02e95a19b40698151cc70d67a62f5b02be0327489c4717eccbd6b919c6a66ff
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - pandas >=2.0.0,<3.0.0
+    - protobuf >=3.20.3,<5.0.0
+    - pyarrow >=10.0.0,<16.0.0
+    - requests-toolbelt ==1.0.0
+
+test:
+  imports:
+    - railib
+    - railib.pb
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://relational.ai/
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "The RelationalAI Software Development Kit for Python"
+  description: |
+    The RelationalAI (RAI) SDK for Python enables developers to access
+    the RAI REST APIs from Python.
+  doc_url: https://docs.relational.ai/rkgms/sdk/python-sdk
+  dev_url: https://github.com/RelationalAI/rai-sdk-python
+
+extra:
+  recipe-maintainers:
+    - ifitchet


### PR DESCRIPTION
rai-sdk 0.7.4 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4600]
- dev_url (pypi): https://github.com/RelationalAI/rai-sdk-python/tree/v0.7.4
- conda-forge: _feedstock not found on conda-forge_
- pypi: https://pypi.org/project/rai-sdk/0.7.4

- pypi inspector: https://inspector.pypi.io/project/rai-sdk/0.7.4

### Explanation of changes:

- new feedstock
- new recipe (pypi)
- upstream tests (unit only; integration uses GH secrets & grpc)


[PKG-4600]: https://anaconda.atlassian.net/browse/PKG-4600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ